### PR TITLE
support set ufm information via parameters

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2021"
 [dependencies]
 ufmclient = { path = "../client" }
 tokio = { version = "1", features = ["full"] }
-clap = { version = "4.1", features = ["derive"] }
+clap = { version = "4.1", features = ["derive", "env"] }
 env_logger = { version = "0.10" }
 


### PR DESCRIPTION
user could set ufm address, username, password or token via parameters. Prevent ufm information from leaking through environment variables.

```
ufmcli -h
UFM command line

Usage: ufmcli [OPTIONS] [COMMAND]

Commands:
  view     View the detail of the partition
  list     List all partitions
  version  Get the version of UFM
  delete   Delete the partition
  create   Create a partition
  help     Print this message or the help of the given subcommand(s)

Options:
      --ufm-address <UFM_ADDRESS>    
      --ufm-username <UFM_USERNAME>  
      --ufm-password <UFM_PASSWORD>  
      --ufm-token <UFM_TOKEN>        
  -h, --help                         Print help
  -V, --version                      Print version
```


```
ufmcli --ufm-address=http://hpc-cloud-gw.mtr.labs.mlnx:4402 --ufm-token=KFQRdrcegilgmUbrzUV1zu5RMWcZ5g list
Name           Pkey      IPoIB     MTU       Rate      Level     
api_pkey_0x2   0x2       true      2         2.5       0         
management     0x7fff    true      2         2.5       0
```